### PR TITLE
fix: Update AdminLayout link to point directly to Horses page

### DIFF
--- a/client/client/src/components/AdminLayout.jsx
+++ b/client/client/src/components/AdminLayout.jsx
@@ -31,7 +31,7 @@ const AdminLayout = () => {
               <IconHorse className="w-8 h-8 text-indigo-700" />
             </a>
             <Link
-              to="/admin"
+              to="/admin/horses"
               className="flex items-center gap-2 text-gray-700 hover:text-indigo-700 font-medium"
             >
               Horses


### PR DESCRIPTION
This pull request includes a small change to the `AdminLayout` component. The change updates the navigation link to point to `/admin/horses` instead of `/admin`.